### PR TITLE
Aggiornamento generale lista dei meetup

### DIFF
--- a/meetup/organizzatori.md
+++ b/meetup/organizzatori.md
@@ -1,31 +1,31 @@
 ## Lista
 
-1.  [Ancona](http://www.meetup.com/it-IT/Meetup-WordPress-Ancona/) @margheweb
-2.  [Andria](https://www.meetup.com/it-IT/WordPress-Meetup-Andria/) @antoniomoschetta
-3.  [Aosta](http://www.meetup.com/WordPress-Meetup-Aosta/) @misamee
-4.  [Arezzo](https://www.meetup.com/it-IT/preview/Arezzo-WordPress-Meetup) @giacomocariulo78
-5.  [Avezzano](http://www.meetup.com/it-IT/WordPress-Meetup-Avezzano/) @sel @fabiomattei @domsal79
-6.  [Bari](http://www.meetup.com/it-IT/WordPress-Meetup-Bari/) @francescocozzi @koolinus
-7.  [Barletta](http://www.meetup.com/it/Barletta-WordPress-Meetup) @francescodicandia
-8.  [Biella](https://www.meetup.com/it-IT/WordPress-Meetup-Biella/) @chiara.lovelaces @eleby
-9.  [Bologna](http://www.meetup.com/WordPress-Meetup-Bologna/) @lucatume @overclokk
-10.  [Brescia](http://www.meetup.com/it/WordPress-Meetup-Brescia/) @tixx @massimo
-11.  [Brindisi](https://www.meetup.com/it-IT/WordPress-Meetup-Brindisi/) @antotrifiroconaccento
-12.  [Catania](http://www.meetup.com/it-IT/Meetup-WordPress-Catania/) @antoscarface @francgrasso @wido
-13.  [Genova](http://www.meetup.com/it/WordPress-Meetup-Genova/) @andg
-14.  [Lecce](https://www.meetup.com/it-IT/WordPress-Meetup-Lecce/) @giulianogrowler @marco_desangro
-14.  [Milano](http://www.meetup.com/WordPress-Meetup-Milano/) @realloc @jubstuff @garusky @paperplane @pjska
-15.  [Padova](http://www.meetup.com/it-IT/Padova-WordPress-Meetup/) @alessandro-vecchiato
-16.  [Palermo](https://www.meetup.com/it-IT/Palermo-WordPress-Meetup/) @andreabarghigiani
-17.  [Parma](http://www.meetup.com/it-IT/WordPress-Meetup-Parma/) @casiepa @lisaaimi
-18.  [Piacenza](http://www.meetup.com/it-IT/Piacenza-WordPress-Meetup/) @renzobassi
-19.  [Ragusa](https://www.meetup.com/it-IT/wordpress-meetup-ragusa/) @robertochibbaro @nenella
-20.  [Reggio Emilia](http://www.meetup.com/WordPress-Community-Reggio-Emilia/) @cieffe27 @sghedo
-21.  [Roma](http://www.meetup.com/RomaWordPress/) @eugeniopetulla
-22.  [Romagna](http://www.meetup.com/Romagna-WordPress-Meetup/) @mauriziomelandri @cardy
-23.  [Teramo](https://www.meetup.com/it-IT/WordPress-Meetup-Teramo/) @marcochiesi @Clodio Solitario
-24.  [Torino](http://www.meetup.com/WordPress-Meetup-Torino/) @cristianozanca @catortorella @ljuba_davie @lasacco @ironicmoka @glorialchemica
-25.  [Treviso](https://www.meetup.com/it-IT/Treviso-WordPress-Meetup/) @rosettafacciolini
-26.  [Udine](https://www.meetup.com/it-IT/Udine-WordPress-Meeup) @lucasartoni
-27.  [Verona](http://www.meetup.com/it-IT/Verona-WordPress-Meetup/) @carriedesign @giuliatosato
-28.  [Vicenza](https://www.meetup.com/it-IT/WordPress-Meetup-Vicenza/) @tamara-it
+1.  [Ancona](https://www.meetup.com/it-IT/Meetup-WordPress-Ancona/) @margheweb
+1.  [Andria](https://www.meetup.com/it-IT/WordPress-Meetup-Andria/) @antoniomoschetta
+1.  [Arezzo](https://www.meetup.com/it-IT/Arezzo-WordPress-Meetup/) @giacomocariulo78
+1.  [Avezzano](https://www.meetup.com/it-IT/WordPress-Meetup-Avezzano/) @sel @fabiomattei @domsal79
+1.  [Bari](https://www.meetup.com/it-IT/WordPress-Meetup-Bari/) @francescocozzi @koolinus
+1.  [Barletta](https://www.meetup.com/it/Barletta-WordPress-Meetup) @francescodicandia
+1.  [Biella](https://www.meetup.com/it-IT/WordPress-Meetup-Biella/) @chiara.lovelaces @eleby
+1.  [Bologna](https://www.meetup.com/WordPress-Meetup-Bologna/) @lucatume @overclokk
+1.  [Brescia](https://www.meetup.com/it/WordPress-Meetup-Brescia/) @tixx @massimo
+1.  [Brindisi](https://www.meetup.com/it-IT/WordPress-Meetup-Brindisi/) @antotrifiroconaccento
+1.  [Catania](https://www.meetup.com/it-IT/Meetup-WordPress-Catania/) @antoscarface @francgrasso @wido
+1.  [Genova](https://www.meetup.com/it/WordPress-Meetup-Genova/) @andg
+1.  [Lecce](https://www.meetup.com/it-IT/WordPress-Meetup-Lecce/) @giulianogrowler @marco_desangro
+1.  [Milano](https://www.meetup.com/WordPress-Meetup-Milano/) @realloc @jubstuff @garusky @paperplane @pjska
+1.  [Padova](https://www.meetup.com/it-IT/Padova-WordPress-Meetup/) @alessandro-vecchiato
+1.  [Palermo](https://www.meetup.com/it-IT/Palermo-WordPress-Meetup/) @andreabarghigiani
+1.  [Parma](https://www.meetup.com/it-IT/WordPress-Meetup-Parma/) @casiepa @lisaaimi
+1.  [Piacenza](https://www.meetup.com/it-IT/Piacenza-WordPress-Meetup/) @renzobassi
+1.  [Ragusa](https://www.meetup.com/it-IT/wordpress-meetup-ragusa/) @robertochibbaro @nenella
+1.  [Reggio Emilia](https://www.meetup.com/it-IT/Reggio-Emilia-WordPress-Meetup/) @Francesco Canovi @valeazzi
+1.  [Roma](https://www.meetup.com/RomaWordPress/) @eugeniopetulla
+1.  [Romagna](https://www.meetup.com/Romagna-WordPress-Meetup/) @mauriziomelandri @cardy
+1.  [Teramo](https://www.meetup.com/it-IT/WordPress-Meetup-Teramo/) @marcochiesi @Clodio Solitario
+1.  [Terni](https://www.meetup.com/it-IT/WordPress-Meetup-Terni/) @eleonora
+1.  [Torino](https://www.meetup.com/WordPress-Meetup-Torino/) @cristianozanca @catortorella @ljuba_davie @lasacco @ironicmoka @glorialchemica
+1.  [Treviso](https://www.meetup.com/it-IT/Treviso-WordPress-Meetup/) @rosettafacciolini
+1.  [Udine](https://www.meetup.com/it-IT/Udine-WordPress-Meeup) @lucasartoni
+1.  [Verona](https://www.meetup.com/it-IT/Verona-WordPress-Meetup/) @carriedesign @giuliatosato
+1.  [Vicenza](https://www.meetup.com/it-IT/WordPress-Meetup-Vicenza/) @tamara-it


### PR DESCRIPTION
Modifiche generali:
- Modificati i numeri per semplificare le modifiche future ed evitare di dover riscrivere a mano tutti i numeri in caso di inserimenti/rimozioni. Il risultato visualizzato è comunque un elenco numerato.
- Convertiti tutti i link alla versione https

Modifiche specifiche:
- Aosta: rimosso in quanto non esiste più, non è neppure elencato su https://it.wordpress.org/meetup/
- Arezzo: corretto il link (il precedente non funzionava)
- Reggio Emilia: aggiornato il link e cambiati gli organizzatori
- Terni: aggiunto nuovo meetup